### PR TITLE
Update version to 1.60.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 !/**/
 # Don't ignore any files/folders recursively in the following folders
 !/recipe/**
+!/abs.yaml
 !/.ci_support/**
 
 # Since we ignore files/folders recursively, any folders inside

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes
+

--- a/recipe/fix_tests.patch
+++ b/recipe/fix_tests.patch
@@ -1,14 +1,14 @@
 diff --git a/google/genai/tests/types/test_types.py b/google/genai/tests/types/test_types.py
-index f85cdc6..83aaa03 100644
+index 531a5c5..a498902 100644
 --- a/google/genai/tests/types/test_types.py
 +++ b/google/genai/tests/types/test_types.py
-@@ -17,7 +17,8 @@
- import copy
+@@ -18,7 +18,8 @@ import copy
+ import json
  import sys
  import typing
 -from typing import Optional, assert_never
 +from typing import Optional
 +from typing_extensions import assert_never
+ import PIL.Image
  import pydantic
  import pytest
- from ... import types

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -83,7 +83,8 @@ test:
     - pip
     - mcp # [py<314]
     # Newer pytest version provoke errors because of deprecated fextures in tests
-    - pytest 8.3.4 
+    - pytest 8.3.4 # [py<314]
+    - pytest >=9.0.0 # [py314]
     - protobuf
     - sentencepiece
     - pillow

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "google-genai" %}
-{% set version = "1.41.0" %}
+{% set version = "1.60.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,13 +7,13 @@ package:
 
 source:
   url: https://github.com/{{ name.split('-')[0] }}apis/python-{{ name.split('-')[1] }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 4849f3c7e5d313806e4563039230f31bea075b21665364cdba40f7b90bca0310
+  sha256: f39207d9f95c50ca2540e940f16fe1e2b89e510a7adac7fe796aa0e5ecaab6fa
   patches:            # [py<311]
     - fix_tests.patch # [py<311]
 
 build:
   number: 0
-  skip: True # [py<39]
+  skip: True # [py<310]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
@@ -28,13 +28,15 @@ requirements:
   run:
     - python
     - anyio >=4.8.0,<5.0.0
-    - google-auth >=2.14.1,<3.0.0
+    - google-auth >=2.47.0,<3.0.0
     - httpx >=0.28.1,<1.0.0
-    - pydantic >=2.0.0,<3.0.0
+    - pydantic >=2.9.0,<3.0.0
     - requests >=2.28.1,<3.0.0
     - tenacity >=8.2.3,<9.2.0
     - websockets >=13.0.0,<15.1.0
     - typing_extensions >=4.11.0,<5.0.0
+    - distro >=1.7.0,<2
+    - sniffio
   run_constrained:
     # aiohttp
     - aiohttp <4.0.0
@@ -71,11 +73,11 @@ test:
     - pip check
     - export GOOGLE_GENAI_REPLAYS_DIRECTORY=${PREFIX}/test_replays # [not win]
     - set GOOGLE_GENAI_REPLAYS_DIRECTORY=${PREFIX}/test_replays # [win]
-    - pytest -v {{ ignored_tests | join(" ") }} # [py>39]
-    - pytest -v {{ ignored_tests | join(" ") }} {{ ignore_mcp_depended_tests | join(" ") }} # [py39]
+    - pytest -v {{ ignored_tests | join(" ") }} # [py<314]
+    - pytest -v {{ ignored_tests | join(" ") }} {{ ignore_mcp_depended_tests | join(" ") }} # [py314]
   requires:
     - pip
-    - mcp # [py>39]
+    - mcp # [py<314]
     - pytest
     - protobuf
     - sentencepiece

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,6 +53,9 @@ requirements:
   "--ignore=google/genai/tests/chats",
   "--ignore=google/genai/tests/caches",
   "--ignore=google/genai/tests/batches",
+  "--ignore=google/genai/tests/file_search_stores",
+  "--ignore=google/genai/tests/documents",
+  "--ignore=google/genai/tests/interactions/test_paths.py",
   "--deselect=google/genai/tests/operations/test_get.py::test_project_operation_get",
   "--deselect=google/genai/tests/public_samples/test_gemini_text_only.py::test_sample",
   "--deselect=google/genai/tests/afc/test_generate_content_stream_afc_thoughts.py::test_generate_content_stream_with_function_and_thought_summaries",
@@ -66,6 +69,7 @@ requirements:
 test:
   source_files:
     - google/genai
+    - pyproject.toml
   imports:
     - google.genai
     - google.genai.types
@@ -78,7 +82,8 @@ test:
   requires:
     - pip
     - mcp # [py<314]
-    - pytest
+    # Newer pytest version provoke errors because of deprecated fextures in tests
+    - pytest 8.3.4 
     - protobuf
     - sentencepiece
     - pillow

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,7 @@ requirements:
     - sniffio
   run_constrained:
     # aiohttp
-    - aiohttp <4.0.0
+    - aiohttp <3.13.3
     # local-tokenizer
     - sentencepiece >=0.2.0
 


### PR DESCRIPTION
google-genai 1.60.0

**Destination channel:** defaults

### Links

- [PKG-11443](https://anaconda.atlassian.net/browse/PKG-11443) 
- [Upstream repository](https://github.com/googleapis/python-genai)

### Explanation of changes:

- New version number
- Updating dependencies versions


[PKG-11443]: https://anaconda.atlassian.net/browse/PKG-11443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ